### PR TITLE
Replace deprecated draw2d repository

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/peterhellberg/karta/diagram"
 	"github.com/peterhellberg/karta/palette"
 
-	"code.google.com/p/draw2d/draw2d"
+	"github.com/llgcode/draw2d"
 )
 
 // Generate generates a map


### PR DESCRIPTION
The code.google.com draw2d repository is deprecated. It will be deleted. This PR migrates to the new official github repository, which has now also a pdf backend (draw2dpdf). 

If you want Karta can now also export pdfs with your same code, see https://github.com/llgcode/draw2d/tree/master/draw2dpdf
https://github.com/llgcode/draw2d

Examples of pdf output:
https://raw.githubusercontent.com/llgcode/draw2d/master/resource/image/geometry.pdf
https://raw.githubusercontent.com/llgcode/draw2d/master/resource/image/postscript.pdf
